### PR TITLE
Remove custom archive parsing; use `clap::value_enum`

### DIFF
--- a/lychee-bin/src/archive/mod.rs
+++ b/lychee-bin/src/archive/mod.rs
@@ -1,7 +1,6 @@
-use serde::{Deserialize, Serialize};
-use strum::{Display, EnumIter, EnumString};
-
 use reqwest::{Error, Url};
+use serde::{Deserialize, Serialize};
+use strum::{Display, EnumIter, EnumString, EnumVariantNames};
 
 mod wayback;
 
@@ -12,7 +11,7 @@ pub(crate) struct Suggestion {
 }
 
 #[non_exhaustive]
-#[derive(Debug, Deserialize, Default, Clone, Display, EnumIter, EnumString)]
+#[derive(Debug, Deserialize, Default, Clone, Display, EnumIter, EnumString, EnumVariantNames)]
 pub(crate) enum Archive {
     #[serde(rename = "wayback")]
     #[strum(serialize = "wayback", ascii_case_insensitive)]

--- a/lychee-bin/src/commands/check.rs
+++ b/lychee-bin/src/commands/check.rs
@@ -79,7 +79,7 @@ where
     }
 
     if params.cfg.suggest {
-        suggest_archived_links(params.cfg.archive, &mut stats).await;
+        suggest_archived_links(params.cfg.archive.unwrap_or_default(), &mut stats).await;
     }
 
     let code = if stats.is_success() {

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -1,8 +1,8 @@
 use crate::archive::Archive;
-use crate::parse::{parse_archive_provider, parse_base, parse_statuscodes};
+use crate::parse::{parse_base, parse_statuscodes};
 use crate::verbosity::Verbosity;
 use anyhow::{anyhow, Context, Error, Result};
-use clap::{arg, Parser};
+use clap::{arg, builder::TypedValueParser, Parser};
 use const_format::{concatcp, formatcp};
 use lychee_lib::{
     Base, Input, DEFAULT_MAX_REDIRECTS, DEFAULT_MAX_RETRIES, DEFAULT_RETRY_WAIT_TIME_SECS,
@@ -12,6 +12,7 @@ use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 use std::path::Path;
 use std::{collections::HashSet, fs, path::PathBuf, str::FromStr, time::Duration};
+use strum::VariantNames;
 
 pub(crate) const LYCHEE_IGNORE_FILE: &str = ".lycheeignore";
 pub(crate) const LYCHEE_CACHE_FILE: &str = ".lycheecache";
@@ -182,8 +183,8 @@ pub(crate) struct Config {
 
     /// Specify the use of a specific web archive.
     /// Can be used in combination with `--suggest`
-    #[arg(long, value_parser = parse_archive_provider, default_value = "wayback")]
-    pub(crate) archive: Archive,
+    #[arg(long, value_parser = clap::builder::PossibleValuesParser::new(Archive::VARIANTS).map(|s| s.parse::<Archive>().unwrap()))]
+    pub(crate) archive: Option<Archive>,
 
     /// Suggest link replacements for broken links, using a web archive.
     /// The web archive can be specified with `--archive`

--- a/lychee-bin/src/parse.rs
+++ b/lychee-bin/src/parse.rs
@@ -2,9 +2,6 @@ use anyhow::{anyhow, Context, Result};
 use headers::{authorization::Basic, Authorization, HeaderMap, HeaderName};
 use lychee_lib::{remap::Remaps, Base};
 use std::{collections::HashSet, time::Duration};
-use strum::IntoEnumIterator;
-
-use crate::archive::Archive;
 
 /// Split a single HTTP header into a (key, value) tuple
 fn read_header(input: &str) -> Result<(String, String)> {
@@ -53,20 +50,6 @@ pub(crate) fn parse_basic_auth(auth: &str) -> Result<Authorization<Basic>> {
 
 pub(crate) fn parse_base(src: &str) -> Result<Base, lychee_lib::ErrorKind> {
     Base::try_from(src)
-}
-
-/// Parse archive provider. If it cannot be parsed, a list of supported
-/// providers is returned.
-pub(crate) fn parse_archive_provider(provider: &str) -> Result<Archive> {
-    Archive::try_from(provider).map_err(|_| {
-        anyhow!(
-            "Supported providers: {}",
-            Archive::iter()
-                .map(|variant| variant.to_string())
-                .collect::<Vec<_>>()
-                .join(", ")
-        )
-    })
 }
 
 /// Parse HTTP status codes into a set of `StatusCode`


### PR DESCRIPTION
Removes custom parsing code.
See https://github.com/lycheeverse/lychee/pull/1003#discussion_r1141926029.